### PR TITLE
cm: Always verify against current CMSDK version.

### DIFF
--- a/build/tasks/apicheck.mk
+++ b/build/tasks/apicheck.mk
@@ -25,11 +25,8 @@ ifeq (,$(filter true, $(WITHOUT_CHECK_API) $(TARGET_BUILD_PDK)))
 # Run the checkapi rules by default.
 droidcore: checkapi-cm
 
-cm_last_released_sdk_version := $(lastword $(call numerically_sort, \
-            $(filter-out current, \
-                $(patsubst $(CM_SRC_API_DIR)/%.txt,%, $(wildcard $(CM_SRC_API_DIR)/*.txt)) \
-             )\
-        ))
+# Validate against current platform sdk version api text within prebuilts
+cm_last_released_sdk_version := $(CM_PLATFORM_SDK_VERSION)
 
 .PHONY: check-cm-public-api
 checkapi-cm : check-cm-public-api


### PR DESCRIPTION
  Since cmsdk prebuilts lives in a single master branch,
  previous branches that apicheck will fail since they'll
  verify against an api that exists in future releases.

Change-Id: I56594d075b89cb1a3d7a606cc9c1699dfffd94cb
TICKET: CYNGNOS-2220
(cherry picked from commit 6a04a23a52642ec226e6e2b1eeab4498b0923b06)