### PR TITLE
config: Lower the priority of vendor/cm overlays

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -225,7 +225,7 @@ endif
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.root_access=0
 
-PRODUCT_PACKAGE_OVERLAYS += vendor/cm/overlay/common
+DEVICE_PACKAGE_OVERLAYS += vendor/cm/overlay/common
 
 PRODUCT_VERSION_MAJOR = 13
 PRODUCT_VERSION_MINOR = 0


### PR DESCRIPTION
The priority order for overlays is PRODUCT > DEVICE > LOCAL
Having PRODUCT here was overriding all of the DEVICE_ specifics
mentioned in device repositories, which was not the intent.
vendor/cm is present as a set of sane defaults, but for the most
part these overlays are intended to be overridable by the device
if needed.

The logic is that PRODUCT_PACKAGE_OVERLAYS should be used by a
particular product while DEVICE_PACKAGE_OVERLAYS is used by
several products that share common device configs. Yeah, the naming
is counterintiuitive, but that's the implementation in
build/core/package_internal.mk

Partially addresses CYNGNOS-2229

Change-Id: Icfbc92593e37f3c00c3d26dd09e08d09267621ed
(cherry picked from commit 15c9ef4cc3c4786767a5db6a9e20c6486c21389a)