### PR TITLE
sepolicy: Allow recovery to mount on tmpfs

### DIFF
--- a/sepolicy/recovery.te
+++ b/sepolicy/recovery.te
@@ -19,6 +19,7 @@ allow recovery rootfs:file link;
 allow recovery rootfs:dir { write create rmdir add_name remove_name };
 
 # Read storage files and directories
+allow recovery tmpfs:dir mounton;
 allow recovery media_rw_data_file:dir r_dir_perms;
 allow recovery media_rw_data_file:file r_file_perms;
 allow recovery vfat:dir r_dir_perms;


### PR DESCRIPTION
/storage is a tmpfs volume, and is where updater stores its zip
when downloading updates.  Devices with emmc partitions that are
used as 'sdcard' volumes will end up with paths like:

  /storage/UUID/...../update.zip

where UUID is the mount point for the partition and update.zip is
the downloaded update.  With this change, minivold can create the
UUID folder and mount onto it, fixing the application of updates.

Change-Id: I4fa84fd590f5ff0f91e38c49cef0c179728fdf43