### PR TITLE
kernel: Default to androidkernel toochains

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -32,9 +32,9 @@
 #   TARGET_USES_UNCOMPRESSED_KERNEL    = 'true' if Kernel is uncompressed,
 #                                          optional, defaults to false
 #   TARGET_KERNEL_CROSS_COMPILE_PREFIX = Compiler prefix (e.g. arm-eabi-)
-#                                          defaults to arm-linux-androideabi- for arm
-#                                                      aarch64-linux-android- for arm64
-#                                                      x86_64-linux-android- for x86
+#                                          defaults to arm-linux-androidkernel- for arm
+#                                                      aarch64-linux-androidkernel- for arm64
+#                                                      x86_64-linux-androidkernel- for x86
 #
 #   BOARD_KERNEL_IMAGE_NAME            = Built image name, optional,
 #                                          defaults to Image.gz on arm64
@@ -215,11 +215,11 @@ TARGET_KERNEL_CROSS_COMPILE_PREFIX := $(strip $(TARGET_KERNEL_CROSS_COMPILE_PREF
 ifneq ($(TARGET_KERNEL_CROSS_COMPILE_PREFIX),)
 KERNEL_TOOLCHAIN_PREFIX ?= $(TARGET_KERNEL_CROSS_COMPILE_PREFIX)
 else ifeq ($(TARGET_ARCH),arm64)
-KERNEL_TOOLCHAIN_PREFIX ?= aarch64-linux-android-
+KERNEL_TOOLCHAIN_PREFIX ?= aarch64-linux-androidkernel-
 else ifeq ($(TARGET_ARCH),arm)
-KERNEL_TOOLCHAIN_PREFIX ?= arm-linux-androideabi-
+KERNEL_TOOLCHAIN_PREFIX ?= arm-linux-androidkernel-
 else ifeq ($(TARGET_ARCH),x86)
-KERNEL_TOOLCHAIN_PREFIX ?= x86_64-linux-android-
+KERNEL_TOOLCHAIN_PREFIX ?= x86_64-linux-androidkernel-
 endif
 
 ifeq ($(KERNEL_TOOLCHAIN),)


### PR DESCRIPTION
* androidkernel is a set of toolchain symlinks for kernel builds that
point to the regular toolchain binaries, except with ld pointing to bfd
instead of gold.

Change-Id: Id1e2d3b1c50db581bff13cfa00b5b35d5badb8ed