### PR TITLE
backuptool: /system/addon.d explicit creation

### DIFF
--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -22,6 +22,7 @@ preserve_addon_d() {
 # Restore /system/addon.d from /tmp/addon.d
 restore_addon_d() {
   if [ -d /tmp/addon.d/ ]; then
+    mkdir -p /system/addon.d/
     cp -a /tmp/addon.d/* /system/addon.d/
     rm -rf /tmp/addon.d/
   fi


### PR DESCRIPTION
 * Add the addon.d folder creation to preserve_addon_d
    before copying the files back to /system/addon.d

 * On CM based ROMs, the path exists for built elements,
    but on other AOSP-based ROMs where this script might
    be used, the folder might not be created on build and
    copy fails, breaking backuptool on second ROM update

Change-Id: I7438823b8d7ad0972649d2bf491d0f6fe423bc99