### PR TITLE
qcom_target: Remove unused support for CAF manifests

### DIFF
--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -80,21 +80,6 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
         endif
     endif
 
-# HACK: check to see if build uses standard QC HAL paths by checking for CM path structure
-AOSP_VARIANT_MAKEFILE := $(wildcard hardware/qcom/audio/default/Android.mk)
-ifeq ("$(AOSP_VARIANT_MAKEFILE)","")
-$(call project-set-path,qcom-audio,hardware/qcom/audio)
-$(call project-set-path,qcom-display,hardware/qcom/display)
-$(call project-set-path,qcom-media,hardware/qcom/media)
-$(call set-device-specific-path,CAMERA,camera,hardware/qcom/camera)
-$(call set-device-specific-path,GPS,gps,hardware/qcom/gps)
-$(call set-device-specific-path,SENSORS,sensors,hardware/qcom/sensors)
-$(call set-device-specific-path,LOC_API,loc-api,vendor/qcom/opensource/location)
-$(call set-device-specific-path,DATASERVICES,dataservices,vendor/qcom/opensource/dataservices)
-$(call project-set-path,ril,hardware/ril)
-$(call project-set-path,wlan,hardware/qcom/wlan)
-$(call project-set-path,bt-vendor,hardware/qcom/bt)
-else
 $(call project-set-path,qcom-audio,hardware/qcom/audio-caf/$(QCOM_HARDWARE_VARIANT))
 $(call project-set-path,qcom-display,hardware/qcom/display-caf/$(QCOM_HARDWARE_VARIANT))
 $(call project-set-path,qcom-media,hardware/qcom/media-caf/$(QCOM_HARDWARE_VARIANT))
@@ -108,7 +93,6 @@ $(call set-device-specific-path,DATASERVICES,dataservices,vendor/qcom/opensource
 $(call ril-set-path-variant,ril)
 $(call wlan-set-path-variant,wlan-caf)
 $(call bt-vendor-set-path-variant,bt-caf)
-endif # AOSP_VARIANT_MAKEFILE
 
 else
 


### PR DESCRIPTION
* This code was introduced to support building from Qualcomm hardware
  manifests, placing the appropriate Qualcomm HALs at the AOSP
  hardware/qcom/$(HAL_TYPE) location. This isn't a supported use case
  anymore, so remove the dead code.

Change-Id: Id7d53b33f53289bc1ead8eb983d7e252940b0387