### PR TITLE
roomservice: Follow fetched android_device_ projects

### DIFF
--- a/build/tools/roomservice.py
+++ b/build/tools/roomservice.py
@@ -201,9 +201,10 @@ def add_to_manifest(repositories, fallback_branch = None):
     f.close()
 
 def fetch_dependencies(repo_path, fallback_branch = None):
-    print('Looking for dependencies')
+    print('Looking for dependencies in %s' % repo_path)
     dependencies_path = repo_path + '/cm.dependencies'
     syncable_repos = []
+    verify_repos = []
 
     if os.path.exists(dependencies_path):
         dependencies_file = open(dependencies_path, 'r')
@@ -214,6 +215,9 @@ def fetch_dependencies(repo_path, fallback_branch = None):
             if not is_in_manifest(dependency['target_path']):
                 fetch_list.append(dependency)
                 syncable_repos.append(dependency['target_path'])
+                verify_repos.append(dependency['target_path'])
+            elif re.search("android_device_.*_.*$", dependency['repository']):
+                verify_repos.append(dependency['target_path'])
 
         dependencies_file.close()
 
@@ -227,7 +231,7 @@ def fetch_dependencies(repo_path, fallback_branch = None):
         print('Syncing dependencies')
         os.system('repo sync --force-sync %s' % ' '.join(syncable_repos))
 
-    for deprepo in syncable_repos:
+    for deprepo in verify_repos:
         fetch_dependencies(deprepo)
 
 def has_branch(branches, revision):


### PR DESCRIPTION
 * In a situation where the Android tree is already
    fetched and entirely set for a device tree,
    all additions to cm.dependencies in a common
    project were ignored due to being already fetched

 * Add a new array of projects to verify but not
    necessarily fetch, and fill it upon fetch request
    or if the project starts with "android_device_",
    to let the iterations follow the common trees

Change-Id: I9eea0ab9c46a4bed8366baa37a4e7e8696481504
Signed-off-by: Adrian DC <radian.dc@gmail.com>