### PR TITLE
Disable SU by default

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -230,8 +230,13 @@ PRODUCT_BOOT_JARS += \
 ifneq ($(TARGET_BUILD_VARIANT),user)
 PRODUCT_PACKAGES += \
     procmem \
-    procrank \
+    procrank
+
+# Conditionally build in su
+ifeq ($(WITH_SU),true)
+PRODUCT_PACKAGES += \
     su
+endif
 endif
 
 DEVICE_PACKAGE_OVERLAYS += vendor/cm/overlay/common


### PR DESCRIPTION
- We plan on distributing an addon for our SU
- Developers that want SU by default can export
    WITH_SU=true to their env
- This helps with application compatibility for
    various services, while maintaining user flexibility

Change-Id: I6d52159676f805c3698ff59c896d943a3a4b25db